### PR TITLE
feat: add mcp server client to tests

### DIFF
--- a/__tests__/e2e/basic.test.ts
+++ b/__tests__/e2e/basic.test.ts
@@ -1,7 +1,0 @@
-import { expect, test } from "@playwright/test"
-
-test.describe("Basic Integration Tests", () => {
-	test("should have a working test environment", async () => {
-		expect(true).toBe(true)
-	})
-})

--- a/__tests__/e2e/fixtures/mcp.ts
+++ b/__tests__/e2e/fixtures/mcp.ts
@@ -1,0 +1,19 @@
+import { test as base } from "@playwright/test"
+
+import { McpClient } from "../helpers/mcp-client"
+
+type TestFixtures = {
+	mcp: McpClient
+}
+
+export const test = base.extend<TestFixtures>({
+	// eslint-disable-next-line no-empty-pattern
+	mcp: async ({}, use) => {
+		const client = new McpClient()
+		await client.start()
+		await use(client)
+		await client.stop()
+	},
+})
+
+export { expect } from "@playwright/test"

--- a/__tests__/e2e/helpers/mcp-client.ts
+++ b/__tests__/e2e/helpers/mcp-client.ts
@@ -1,0 +1,103 @@
+import { type ChildProcess, spawn } from "child_process"
+
+interface ToolCallRequest {
+	jsonrpc: "2.0"
+	id: string
+	method: "tools/call"
+	params: { name: string; arguments: Record<string, unknown> }
+}
+
+interface ToolCallResponse {
+	jsonrpc: "2.0"
+	id: string
+	result?: {
+		content: Array<{
+			type: string
+			text: string
+		}>
+	}
+	error?: {
+		message: string
+	}
+}
+
+export class McpClient {
+	private process: ChildProcess | null = null
+
+	async start(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			this.process = spawn("node", ["bin/stdio.js"], {
+				stdio: ["pipe", "pipe", "pipe"],
+				cwd: process.cwd(),
+			})
+
+			this.process.on("error", reject)
+
+			// Give the server time to start
+			setTimeout(resolve, 1000)
+		})
+	}
+
+	async stop(): Promise<void> {
+		this.process?.kill()
+		this.process = null
+	}
+
+	async callTool(
+		toolName: string,
+		args: Record<string, unknown>,
+	): Promise<string> {
+		if (!this.process?.stdin) {
+			throw new Error("Server not running")
+		}
+
+		const request: ToolCallRequest = {
+			jsonrpc: "2.0",
+			id: "test-1",
+			method: "tools/call",
+			params: { name: toolName, arguments: args },
+		}
+
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => reject(new Error("Timeout")), 15000)
+			let responseData = ""
+
+			const dataHandler = (data: Buffer) => {
+				responseData += data.toString()
+
+				const lines = responseData.split("\n")
+				// Remove and store the last line, which is potentially incomplete
+				responseData = lines.pop() || ""
+
+				for (const line of lines) {
+					if (line.trim()) {
+						try {
+							const response: ToolCallResponse = JSON.parse(line)
+							if (response.id === "test-1") {
+								clearTimeout(timeout)
+								this.process!.stdout!.off("data", dataHandler)
+
+								if (response.error) {
+									reject(new Error(response.error.message))
+								} else {
+									// Combine all content text
+									const content = response.result?.content || []
+									const text = content
+										.filter((item) => item.type === "text")
+										.map((item) => item.text)
+										.join("\n")
+									resolve(text)
+								}
+							}
+						} catch {
+							// Ignore parsing errors for incomplete messages
+						}
+					}
+				}
+			}
+
+			this.process!.stdout!.on("data", dataHandler)
+			this.process!.stdin!.write(JSON.stringify(request) + "\n")
+		})
+	}
+}

--- a/__tests__/e2e/tools/how-to-code-slice.test.ts
+++ b/__tests__/e2e/tools/how-to-code-slice.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "../fixtures/mcp"
+
+test.describe("how_to_code_slice tool", () => {
+	test("should provide guidance for slice with RichTextField", async ({
+		mcp,
+	}) => {
+		const result = await mcp.callTool("how_to_code_slice", {
+			projectFramework: "next",
+			stylingSystemToUse: "tailwind",
+			modelAbsolutePath: "/tmp/model.json",
+			sliceMachineConfigAbsolutePath: "/tmp/slicemachine.config.json",
+			fieldsUsed: ["prismic.RichTextField"],
+		})
+
+		// Validate the content of the result
+		expect(result).toContain("RichTextField")
+		expect(result).toContain("PrismicRichText")
+		expect(result).toContain("field={slice.primary.my_rich_text_field}")
+		expect(typeof result).toBe("string")
+		expect(result.length).toBeGreaterThan(100)
+
+		// Validate that the tool provides comprehensive guidance
+		expect(result).toContain("MANDATORY")
+		expect(result).toContain("Fields documentation")
+		expect(result).toContain("Model analysis")
+		expect(result).toContain("Styling implementation")
+	})
+
+	test("should provide guidance for slice with multiple fields", async ({
+		mcp,
+	}) => {
+		const result = await mcp.callTool("how_to_code_slice", {
+			projectFramework: "nuxt",
+			stylingSystemToUse: "scss",
+			modelAbsolutePath: "/tmp/model.json",
+			sliceMachineConfigAbsolutePath: "/tmp/slicemachine.config.json",
+			fieldsUsed: [
+				"prismic.RichTextField",
+				"prismic.ImageField",
+				"prismic.LinkField",
+			],
+		})
+
+		expect(result).toContain("RichTextField")
+		expect(result).toContain("PrismicRichText")
+		expect(result).toContain(':field=\\"slice.primary.my_rich_text_field\\"')
+
+		expect(result).toContain("ImageField")
+		expect(result).toContain("PrismicImage")
+		expect(result).toContain(':field=\\"slice.primary.my_image_field\\"')
+
+		expect(result).toContain("LinkField")
+		expect(result).toContain("PrismicLink")
+		expect(result).toContain(':field=\\"slice.primary.my_link_field\\"')
+
+		expect(typeof result).toBe("string")
+		expect(result.length).toBeGreaterThan(100)
+	})
+
+	test("should provide comprehensive field documentation", async ({ mcp }) => {
+		const result = await mcp.callTool("how_to_code_slice", {
+			projectFramework: "next",
+			stylingSystemToUse: "tailwind",
+			modelAbsolutePath: "/tmp/model.json",
+			sliceMachineConfigAbsolutePath: "/tmp/slicemachine.config.json",
+			fieldsUsed: [
+				"prismic.TitleField",
+				"prismic.RichTextField",
+				"prismic.ImageField",
+				"prismic.LinkField",
+				"prismic.SelectField",
+				"prismic.BooleanField",
+				"prismic.NumberField",
+				"prismic.DateField",
+				"prismic.ColorField",
+				"prismic.EmbedField",
+				"prismic.GeoPointField",
+				"prismic.IntegrationField",
+				"prismic.LinkToMediaField",
+				"prismic.TableField",
+				"prismic.KeyTextField",
+				"prismic.TimestampField",
+				"prismic.GroupField",
+				"prismic.ContentRelationshipField",
+			],
+		})
+
+		const fieldTypes = [
+			"TitleField",
+			"RichTextField",
+			"ImageField",
+			"LinkField",
+			"SelectField",
+			"BooleanField",
+			"NumberField",
+			"DateField",
+			"ColorField",
+			"EmbedField",
+			"GeoPointField",
+			"IntegrationField",
+			"LinkToMediaField",
+			"TableField",
+			"KeyTextField",
+			"TimestampField",
+			"GroupField",
+			"ContentRelationshipField",
+		]
+
+		fieldTypes.forEach((fieldType) => {
+			expect(result).toContain(fieldType)
+		})
+		expect(typeof result).toBe("string")
+		expect(result.length).toBeGreaterThan(100)
+	})
+
+	test.only("should handle missing parameters gracefully", async ({ mcp }) => {
+		try {
+			await mcp.callTool("how_to_code_slice", {
+				projectFramework: "next",
+			})
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error)
+		}
+	})
+})


### PR DESCRIPTION
Resolves: [DT-2872](https://linear.app/prismic/issue/DT-2872/add-mcp-server-to-test-fixtures)

### Description

This PR adds an MCP Server client to the test fixtures. It also adds the first test file for the `how_to_code_slice` tool. 

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
