### PR TITLE
feat: add add_slice_to_custom_type tool

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -58,6 +58,14 @@ type TelemetryTrackArgs =
 			sliceMachineConfigAbsolutePath: string
 			properties?: never
 	  }
+	| {
+			event: "MCP Tool - Add slice to custom type"
+			sliceMachineConfigAbsolutePath: string
+			properties: {
+				sliceName: string
+				customTypeId: string
+			}
+	  }
 
 export class Telemetry {
 	private _segmentClient: Analytics | undefined = undefined

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { Telemetry } from "./lib/telemetry"
 
 import { name, version } from "../package.json"
 
+import { add_slice_to_custom_type } from "./tools/add_slice_to_custom_type"
 import { generate_types } from "./tools/generate_types"
 import { how_to_code_slice } from "./tools/how_to_code_slice"
 import { how_to_mock_slice } from "./tools/how_to_mock_slice"
@@ -21,3 +22,4 @@ server.tool(...verify_slice_model)
 server.tool(...how_to_mock_slice)
 server.tool(...verify_slice_mock)
 server.tool(...generate_types)
+server.tool(...add_slice_to_custom_type)

--- a/src/tools/add_slice_to_custom_type.ts
+++ b/src/tools/add_slice_to_custom_type.ts
@@ -1,0 +1,186 @@
+import { readFileSync, writeFileSync } from "fs"
+import { basename, join as joinPath } from "path"
+import { z } from "zod"
+
+import { formatErrorForMcpTool } from "../lib/error"
+import { tool } from "../lib/mcp"
+import {
+	type DynamicSlices,
+	type SharedSlice,
+	type StaticCustomType,
+} from "@prismicio/types-internal/lib/customtypes"
+
+import { telemetryClient } from "../server"
+
+export const add_slice_to_custom_type = tool(
+	"add_slice_to_custom_type",
+	`PURPOSE: Adds a slice to a page or custom type.
+
+USAGE: Use to add a given slice to a certain custom type.
+
+RETURNS: A message indicating whether the slice was added to the type or not, and detailed error messages if it is not.`,
+	z.object({
+		sliceMachineConfigAbsolutePath: z
+			.string()
+			.describe("Absolute path to 'slicemachine.config.json' file"),
+		sliceDirectoryAbsolutePath: z
+			.string()
+			.describe("Absolute path to the slice directory (contains 'model.json')"),
+		customTypeDirectoryAbsolutePath: z
+			.string()
+			.describe(
+				"Absolute path to the custom type directory (contains 'index.json')",
+			),
+	}).shape,
+	(args) => {
+		const { sliceDirectoryAbsolutePath, customTypeDirectoryAbsolutePath } = args
+
+		try {
+			try {
+				telemetryClient.track({
+					event: "MCP Tool - Add slice to custom type",
+					sliceMachineConfigAbsolutePath: args.sliceMachineConfigAbsolutePath,
+					properties: {
+						sliceName: basename(sliceDirectoryAbsolutePath),
+						customTypeId: basename(customTypeDirectoryAbsolutePath),
+					},
+				})
+			} catch (error) {
+				// noop, we don't wanna block the tool call if the tracking fails
+				if (process.env.DEBUG) {
+					console.error(
+						"Error while tracking 'add_slice_to_custom_type' tool call",
+						error,
+					)
+				}
+			}
+
+			// Read the slice model
+			const sliceModelAbsolutePath = joinPath(
+				sliceDirectoryAbsolutePath,
+				"model.json",
+			)
+
+			let parsedSliceModel: SharedSlice
+			try {
+				parsedSliceModel = JSON.parse(
+					readFileSync(sliceModelAbsolutePath, "utf-8"),
+				)
+			} catch (error) {
+				throw new Error(
+					`Invalid JSON format for slice model at ${sliceModelAbsolutePath}: ${getErrorMessage(error)}`,
+				)
+			}
+
+			// Read the custom type model
+			const customTypeModelAbsolutePath = joinPath(
+				customTypeDirectoryAbsolutePath,
+				"index.json",
+			)
+
+			let customTypeParsedModel: StaticCustomType
+			try {
+				customTypeParsedModel = JSON.parse(
+					readFileSync(customTypeModelAbsolutePath, "utf-8"),
+				)
+			} catch (error) {
+				throw new Error(
+					`Invalid JSON format for page/custom type model at ${customTypeModelAbsolutePath}: ${getErrorMessage(error)}`,
+				)
+			}
+
+			// Find the slice fields
+			const sliceFields: [string, string][] = []
+			let sliceAlreadyAdded = false
+
+			Object.entries(customTypeParsedModel.json).forEach(
+				([sectionName, fields]) => {
+					Object.entries(fields).forEach(([fieldId, field]) => {
+						if (field?.type === "Slices") {
+							sliceFields.push([sectionName, fieldId])
+
+							if (
+								!sliceAlreadyAdded &&
+								Object.keys(field.config?.choices || {}).includes(
+									parsedSliceModel.id,
+								)
+							) {
+								sliceAlreadyAdded = true
+							}
+						}
+					})
+				},
+			)
+
+			if (sliceAlreadyAdded) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `The "${parsedSliceModel.id}" slice already exists in the "${customTypeParsedModel.id}" custom type`,
+						},
+					],
+				}
+			}
+
+			if (sliceFields.length === 0) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `The "${parsedSliceModel.id}" slice was not added to the "${customTypeParsedModel.id}" custom type because there are no slice fields in the model.`,
+						},
+					],
+				}
+			}
+
+			// Add the slice to the first slice field in the model
+			const [sectionName, fieldId] = sliceFields[0]
+
+			const sliceField: DynamicSlices = customTypeParsedModel.json[sectionName][
+				fieldId
+			] as DynamicSlices
+			if (!sliceField.config) {
+				sliceField.config = {}
+			}
+			if (!sliceField.config.choices) {
+				sliceField.config.choices = {}
+			}
+
+			sliceField.config.choices[parsedSliceModel.id] = {
+				type: parsedSliceModel.type,
+			}
+
+			try {
+				writeFileSync(
+					customTypeModelAbsolutePath,
+					`${JSON.stringify(customTypeParsedModel, null, 2)}\n`,
+					"utf-8",
+				)
+			} catch (error) {
+				throw new Error(
+					`Failed to write to file ${customTypeModelAbsolutePath}: ${getErrorMessage(error)}`,
+				)
+			}
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: `
+The slice model at ${sliceModelAbsolutePath} is now added to the custom type at ${customTypeModelAbsolutePath}.
+
+The next step is to update the Prismic types.
+`,
+					},
+				],
+			}
+		} catch (error) {
+			return formatErrorForMcpTool(error)
+		}
+	},
+)
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error)
+}


### PR DESCRIPTION
Resolves: [DT-2867](https://linear.app/prismic/issue/DT-2867/prismic-mcp-tool-add-slice-to-custom-type-to-add-a-slice-to-a-page)

### Description

This adds a tool to add a slice to a given custom type.
It does the following:
- Reads the slice and CT models
- Finds the slice fields in the CT model
- Checks if the slice already exists in the CT
- Checks if the slice has at least one slice zone field
- Adds the slice to the first slice zone field
- Updates the CT model file
- Responds with success message & next step (update Prismic types)

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
