### PR TITLE
feat: encourage the use of repeatable links instead of groups

### DIFF
--- a/src/tools/how_to_model_slice.ts
+++ b/src/tools/how_to_model_slice.ts
@@ -226,7 +226,7 @@ Notes:
 }
 \`\`\`
 Notes:
-- Use \`repeat\`: true for lists of adjacent buttons/links (better than Group for this use case). This removes the need for multiple separate Link fields.
+- Use \`repeat: true\` for lists of adjacent buttons/links (better than Group for this use case). This removes the need for multiple separate Link fields.
 - Use variants for different button styles (e.g., ["Primary", "Secondary"]).
 - Use allowText to enable custom display text. Always use when the button or link has a label.
 - **Content Relationships**: Set \`select: "document"\` and use \`customtypes\` for field selection. Only selected fields are included in API responses. Up to 2 levels of nesting supported. For nesting to work, target fields must also be content relationship Link fields. Groups don't count toward nesting levels, i.e. a group field can contain a content relationship field that points to another custom type, and that custom type can have a group field with a content relationship field as the second nesting level.


### PR DESCRIPTION
Resolves: [DT-2906](https://linear.app/prismic/issue/DT-2906)

### Description

- Discourage Prismic bad modeling practices, like using a `Group` with a `Text` and `Link` to be able to have adjacent CTAs, rather than to use a `Link` with `repeat: true` and `allowText: true`

### Preview

<img width="1718" height="555" alt="Screenshot 2025-09-17 at 10 44 24" src="https://github.com/user-attachments/assets/1fa44ffd-26f4-43db-9c73-53dff5b5f767" />

<img width="1658" height="709" alt="Screenshot 2025-09-17 at 10 51 52" src="https://github.com/user-attachments/assets/c9c32946-3658-4612-a80a-737fd7a98adf" />

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
