### PR TITLE
feat: ensure ai don't use imgix unless requested

### DIFF
--- a/__tests__/e2e/tools/how-to-code-slice.test.ts
+++ b/__tests__/e2e/tools/how-to-code-slice.test.ts
@@ -79,4 +79,17 @@ test.describe("how_to_code_slice tool - Calling Tool", () => {
 			expect(error).toBeInstanceOf(Error)
 		}
 	})
+
+	test("should handle image field", async () => {
+		const result = await callTool("how_to_code_slice", {
+			projectFramework: "next",
+			stylingSystemToUse: "tailwind",
+			modelAbsolutePath: "/src/slices/Hero/model.json",
+			sliceMachineConfigAbsolutePath: "/slicemachine.config.json",
+			fieldsUsed: ["prismic.ImageField"],
+		})
+		expect(result).toContain(
+			"Only apply imgix transformation when explicitly requested by the user.",
+		)
+	})
 })

--- a/src/tools/how_to_code_slice.ts
+++ b/src/tools/how_to_code_slice.ts
@@ -129,42 +129,88 @@ Implement the desired code changes following the documentation above and project
 )
 
 const PRISMIC_DOCS_BASE = "https://prismic.io/docs/fields"
-const FIELD_PATH_MAPPING = {
-	"prismic.BooleanField": "boolean",
-	"prismic.ColorField": "color",
-	"prismic.ContentRelationshipField": "content-relationship",
-	ContentRelationshipFieldWithData: "content-relationship",
-	"prismic.DateField": "date",
-	"prismic.EmbedField": "embed",
-	"prismic.GeoPointField": "geopoint",
-	"prismic.ImageField": "image",
-	"prismic.IntegrationField": "integration",
-	"prismic.LinkField": "link",
-	"prismic.LinkToMediaField": "link-to-media",
-	"prismic.NumberField": "number",
-	"prismic.GroupField": "repeatable-group",
-	"prismic.RichTextField": "rich-text",
-	"prismic.SelectField": "select",
-	"prismic.TableField": "table",
-	"prismic.TitleField": "rich-text", // Title uses rich text docs
-	"prismic.KeyTextField": "text",
-	"prismic.TimestampField": "timestamp",
-} as const
+const FIELD_MAPPING: Record<string, { path: string; additionalInfo?: string }> =
+	{
+		"prismic.BooleanField": {
+			path: "boolean",
+		},
+		"prismic.ColorField": {
+			path: "color",
+		},
+		"prismic.ContentRelationshipField": {
+			path: "content-relationship",
+		},
+		ContentRelationshipFieldWithData: {
+			path: "content-relationship",
+		},
+		"prismic.DateField": {
+			path: "date",
+		},
+		"prismic.EmbedField": {
+			path: "embed",
+		},
+		"prismic.GeoPointField": {
+			path: "geopoint",
+		},
+		"prismic.ImageField": {
+			path: "image",
+			additionalInfo:
+				"Only apply imgix transformation when explicitly requested by the user.",
+		},
+		"prismic.IntegrationField": {
+			path: "integration",
+		},
+		"prismic.LinkField": {
+			path: "link",
+		},
+		"prismic.LinkToMediaField": {
+			path: "link-to-media",
+		},
+		"prismic.NumberField": {
+			path: "number",
+		},
+		"prismic.GroupField": {
+			path: "repeatable-group",
+		},
+		"prismic.RichTextField": {
+			path: "rich-text",
+		},
+		"prismic.SelectField": {
+			path: "select",
+		},
+		"prismic.TableField": {
+			path: "table",
+		},
+		"prismic.TitleField": {
+			// Title uses rich text docs
+			path: "rich-text",
+		},
+		"prismic.KeyTextField": {
+			path: "text",
+		},
+		"prismic.TimestampField": {
+			path: "timestamp",
+		},
+	} as const
 
 async function fetchFieldDocumentation(fieldType: string): Promise<string> {
-	const path = FIELD_PATH_MAPPING[fieldType as keyof typeof FIELD_PATH_MAPPING]
-	if (!path) {
+	const field = FIELD_MAPPING[fieldType as keyof typeof FIELD_MAPPING]
+	if (!field) {
 		return `No documentation available for field type: ${fieldType}`
 	}
 
-	const url = `${PRISMIC_DOCS_BASE}/${path}.md`
+	const url = `${PRISMIC_DOCS_BASE}/${field.path}.md`
 
 	try {
 		const response = await fetch(url)
 		if (!response.ok) {
 			return `Failed to fetch documentation for ${fieldType}: ${response.status} ${response.statusText}`
 		}
-		const markdown = await response.text()
+		let markdown = await response.text()
+
+		if (field.additionalInfo) {
+			markdown += `\n**Additional Information:** \n${field.additionalInfo}`
+		}
 
 		return markdown
 	} catch (error) {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: [<!-- GitHub or Linear issue (e.g. #123, DT-123) -->](https://linear.app/prismic/issue/DT-2876/prismic-mcp-additional-information-for-how-to-code-slice-tool)

### Description

Ensure AI doesn't use imgx if not requested by the user 

<!-- Describe your changes in detail. Imagine someone who knows nothing about this may read it in 5 years. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!-- Why is this PR good at solving the problem? -->

### Preview

For the request: "Code this slice"

Before:

<img width="1352" height="490" alt="Screenshot 2025-09-23 at 20 25 24" src="https://github.com/user-attachments/assets/eec0d66e-e62a-4145-ab4b-fecb0a91e4f2" />

After:

<img width="1367" height="444" alt="Screenshot 2025-09-23 at 20 20 59" src="https://github.com/user-attachments/assets/6ed9e7a1-1c3b-404c-a0ad-1c326e83ca50" />

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

