### PR TITLE
chore: switch dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,21 @@
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
 
-  # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`
-    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Switch Dependabot schedule from weekly to monthly for both npm and GitHub Actions
- Group all dependencies into a single PR per ecosystem using `patterns: ["*"]`
- Limit open pull requests to 1 per ecosystem

## Test plan
- [ ] Verify CI passes
- [ ] Confirm Dependabot picks up the new config on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that alters Dependabot cadence and grouping; main impact is fewer, larger update PRs which could delay vulnerability patch PRs until the monthly run.
> 
> **Overview**
> Switches Dependabot update cadence from **weekly** to **monthly** for both `npm` and `github-actions`.
> 
> Limits Dependabot to **one open PR per ecosystem** and groups all dependency updates into a single PR via `groups.all-dependencies` with `patterns: ["*"]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb9e190f66fe7cab2c15986622c4814d74105ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->